### PR TITLE
Remove bin/coffeelint

### DIFF
--- a/bin/coffeelint
+++ b/bin/coffeelint
@@ -1,5 +1,0 @@
-#!/usr/bin/env ruby
-
-require 'coffeelint'
-
-Coffeelint::Cmd.main


### PR DESCRIPTION
It's useless and breaks using the actual coffeelint from npm if you have this installed and install the binstubs, or use the rbenv-binstubs plugin (though this is a quirk due to how rbenv and rbenv-binstubs handle git installed gems). Either bin/coffeelint should be installed as an executable as part of the gemspec or it should not exist, all it does is the same thing as coffeelint.rb. It doesn't even take all the options that coffeelint takes so it's not actually a drop in replacement.
